### PR TITLE
ci: deploy docs on gh pages

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,0 +1,42 @@
+name: Doxygen GitHub Pages Deploy
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Setup python environment
+        env:
+          PATH_PYBINDS: ${{ github.workspace }}/bindings/python
+          PATH_PYSTUBS: ${{ github.workspace }}/bindings/python/frenetTransformStubs
+        run: |
+          pip install .[STUBS]
+          python ${{ env.PATH_PYBINDS }}/frenetTransform/build_stubs.py
+
+      - name: Install Doxygen
+        run: sudo apt-get install doxygen graphviz
+
+      - name: Configure CMake
+        run: cmake -B${{github.workspace}}/build -DBUILD_TEST=OFF -DBUILD_BENCHMARK=OFF -DBUILD_DOCS=ON -DBUILD_EXAMPLES=OFF
+
+      - name: Build documentation
+        run: cmake --build ${{github.workspace}}/build
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          folder: build/docs/html


### PR DESCRIPTION
Implement a GitHub Actions workflow to automatically deploy documentation to GitHub Pages upon closing a pull request on the main branch.